### PR TITLE
MainStore: fix callback type and export instance

### DIFF
--- a/lib/store/main_store.dart
+++ b/lib/store/main_store.dart
@@ -11,7 +11,7 @@ class MainStore {
   _init() {
     if (_socket == null) {
       // TODO
-      _socket = IO.io('http://localhost:3000', <String, dynamic>{
+      _socket = IO.io('http://localhost:9092', <String, dynamic>{
         'transports': ['websocket']
       });
       _socket.on('connect', (_) {
@@ -20,7 +20,7 @@ class MainStore {
     }
   }
 
-  StreamSubscription<MainStoreEvent> subscribe(void callback(event)) {
+  StreamSubscription<MainStoreEvent> subscribe(void callback(MainStoreEvent event)) {
     StreamSubscription<MainStoreEvent> subscription = _subject.listen(callback);
     _init();
     return subscription;
@@ -32,3 +32,5 @@ class MainStore {
     }
   }
 }
+
+MainStore mainStore = MainStore();


### PR DESCRIPTION
### Subscribe MainStore usage

##### Step 1: subscribe at initState (Widget lifecycle)

```dart
  @override
  void initState() {
    super.initState();
    subscription = mainStore.subscribe((MainStoreEvent e) {
      print(e.event);
    });
  }
```

##### Step 2: cancel at dispose (Widget lifecycle)

```dart
  @override
  void dispose() {
    super.dispose();
    subscription.cancel();
  }
```


### check list

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with flutter test.)
